### PR TITLE
Add old key support

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -6,21 +6,27 @@ import { makeEncryptor, makeDecryptor } from './helpers'
 const makeSyncEncryptor = secretKey =>
   makeEncryptor(state => AES.encrypt(state, secretKey).toString())
 
+const decryptor = (state, secretKey) => {
+    const bytes = AES.decrypt(state, secretKey)
+    const decryptedString = bytes.toString(CryptoJSCore.enc.Utf8)
+    return JSON.parse(decryptedString)
+}
+
 const makeSyncDecryptor = (secretKey, oldSecretKey, onError) =>
   makeDecryptor(state => {
     try {
-      const bytes = AES.decrypt(state, secretKey)
-      const decryptedString = bytes.toString(CryptoJSCore.enc.Utf8)
-      return JSON.parse(decryptedString)
+        return decryptor(state, secretKey);
     } catch (err) {
-      if (oldSecretKey) {
-         const bytes = AES.decrypt(state, oldSecretKey)
-         const decryptedString = bytes.toString(CryptoJSCore.enc.Utf8)
-         return JSON.parse(decryptedString)
+      try {
+         if (!oldSecretKey) throw new Error(
+             'Could not decrypt state. Please verify that you are using the correct secret key.'
+           );
+         return decryptor(state, oldSecretKey);
+      } catch (e) {
+          throw new Error(
+              'Could not decrypt state. Please verify that you are using the correct secret key.'
+          );
       }
-      throw new Error(
-        'Could not decrypt state. Please verify that you are using the correct secret key.'
-      )
     }
   }, onError)
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -6,13 +6,18 @@ import { makeEncryptor, makeDecryptor } from './helpers'
 const makeSyncEncryptor = secretKey =>
   makeEncryptor(state => AES.encrypt(state, secretKey).toString())
 
-const makeSyncDecryptor = (secretKey, onError) =>
+const makeSyncDecryptor = (secretKey, oldSecretKey, onError) =>
   makeDecryptor(state => {
     try {
       const bytes = AES.decrypt(state, secretKey)
       const decryptedString = bytes.toString(CryptoJSCore.enc.Utf8)
       return JSON.parse(decryptedString)
     } catch (err) {
+      if (oldSecretKey) {
+         const bytes = AES.decrypt(state, oldSecretKey)
+         const decryptedString = bytes.toString(CryptoJSCore.enc.Utf8)
+         return JSON.parse(decryptedString)
+      }
       throw new Error(
         'Could not decrypt state. Please verify that you are using the correct secret key.'
       )
@@ -21,6 +26,6 @@ const makeSyncDecryptor = (secretKey, onError) =>
 
 export default config => {
   const inbound = makeSyncEncryptor(config.secretKey)
-  const outbound = makeSyncDecryptor(config.secretKey, config.onError)
+  const outbound = makeSyncDecryptor(config.secretKey, config.oldSecretKey, config.onError)
   return createTransform(inbound, outbound, config)
 }


### PR DESCRIPTION
Add old key support so that we can update existing secretKey used in production or so.

- we will only be using for decrypting the state. Writing to state will only use the secret key